### PR TITLE
Update latex-preamble-article.tex

### DIFF
--- a/src/latex-preamble-article.tex
+++ b/src/latex-preamble-article.tex
@@ -1,3 +1,4 @@
+\PassOptionsToPackage{ngerman,}{babel}
 \documentclass[a4paper,oneside,11pt,bibtotoc,bibliography=openstyle]{scrartcl}
 \usepackage{scrhack}
 \usepackage[utf8]{inputenc}


### PR DESCRIPTION
fixes the following problem when imported to lyx and converted to PDF or similar: 
LaTeX Error: Option clash for package babel.
The package babel has already been loaded with options:
  []
There has now been an attempt to load it with options
  [ngerman]